### PR TITLE
Fix Action Tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "enzyme-to-json": "^3.3.5",
     "firebase": "^5.7.1",
     "firebaseui": "^3.5.1",
     "prop-types": "^15.6.2",

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -1,39 +1,34 @@
-export const loadBreweries = (breweries) => {
+export const loadBreweries = (breweries) => ({
   type: 'LOAD_BREWERIES',
   breweries
-}
+})
 
-export const loadFoodTrucks = (foodTrucks) => {
+export const loadFoodTrucks = (foodTrucks) => ({
   type: 'LOAD_FOOD_TRUCKS', 
   foodTrucks
-}
+})
 
-export const loadProfile = (profile) => {
+export const loadProfile = (profile) => ({
   type: 'LOAD_PROFILE',
   profile
-}
+})
 
-export const toggleSignedIn = (userStatus) => {
+export const toggleSignedIn = () => ({
   type: 'TOGGLE_SIGNED_IN',
-  userStatus
-}
+  !userStatus
+})
 
-export const loadCancellations = (cancellations) => {
-  type: 'LOAD_CANCELLATIONS',
-  cancellations
-}
-
-export const addEvent = (event) => {
+export const addEvent = (event) => ({
   type: 'ADD_EVENT',
   event
-}
+})
 
-export const removeEvent = (event) => {
+export const removeEvent = (event) => ({
   type: 'REMOVE_EVENT',
   event
-}
+})
 
-export const editEvent = (event) => {
+export const editEvent = (event) => ({
   type: 'EDIT_EVENT',
   event
-}
+})

--- a/src/containers/Login/index.js
+++ b/src/containers/Login/index.js
@@ -35,7 +35,6 @@ export class Login extends Component {
       this.props.firebase
         .doCreateUserWithEmailAndPassword(email, passwordOne)
         .then(authUser => {
-          console.log(authUser.user.uid)
           this.props.history.push('/');
         })
         .catch(error => {
@@ -45,7 +44,6 @@ export class Login extends Component {
       this.props.firebase
         .doSignInWithEmailAndPassword(email, passwordOne)
         .then(authUser => {
-          console.log(authUser)
           this.props.history.push('/')
         })
         .catch(error => {

--- a/src/tests/__snapshots__/App.test.js.snap
+++ b/src/tests/__snapshots__/App.test.js.snap
@@ -1,0 +1,46 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`APP should match the snapshot 1`] = `
+<div
+  className="main"
+>
+  <header>
+    <h1
+      className="main-title"
+    >
+      <span>
+        <img
+          className="truck-icon"
+          src="food-truck.png"
+        />
+      </span>
+      TruckTrackr
+      <span>
+        <img
+          className="barrel-icon"
+          src="barrel-icon-new.png"
+        />
+      </span>
+    </h1>
+    <img
+      className="hamburger-icon"
+      src="hamburger.svg"
+    />
+  </header>
+  <div
+    className="content-holder"
+  >
+    <NavBar />
+    <Route
+      exact={true}
+      path="/login"
+      render={[Function]}
+    />
+    <Route
+      component={[Function]}
+      exact={true}
+      path="/"
+    />
+  </div>
+</div>
+`;

--- a/src/tests/__snapshots__/Login.test.js.snap
+++ b/src/tests/__snapshots__/Login.test.js.snap
@@ -1,0 +1,119 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`LOGIN should match the snapshot 1`] = `
+<main
+  className="login"
+>
+  <form
+    className="login-form"
+    onSubmit={[Function]}
+  >
+    <input
+      className="email-input"
+      name="email"
+      onChange={[Function]}
+      placeholder="Email"
+      type="email"
+    />
+    <input
+      className="password-input"
+      name="passwordOne"
+      onChange={[Function]}
+      placeholder="Password"
+      type="password"
+    />
+    <input
+      className="hidden"
+      name="businessName"
+      onChange={[Function]}
+      placeholder="Business Name"
+    />
+    <input
+      className="hidden"
+      name="address"
+      onChange={[Function]}
+      placeholder="Address/City Located"
+    />
+    <input
+      className="hidden"
+      name="phoneNumber"
+      onChange={[Function]}
+      placeholder="Phone Number"
+    />
+    <input
+      className="hidden"
+      name="contactName"
+      onChange={[Function]}
+      placeholder="Contact Name"
+    />
+    <input
+      className="hidden"
+      name="foodType"
+      onChange={[Function]}
+      placeholder="Food Type"
+    />
+    <p
+      className="hidden"
+    >
+      What Type of Business:
+    </p>
+    <div
+      className="button-holder"
+    >
+      <input
+        className="hidden"
+        id="food-truck-button"
+        name="locationType"
+        onChange={[Function]}
+        type="radio"
+        value="food-truck"
+      />
+      <label
+        className="hidden"
+        for="food-truck-button"
+      >
+        Food Truck
+      </label>
+      <input
+        className="hidden"
+        id="brewery-button"
+        name="locationType"
+        onChange={[Function]}
+        type="radio"
+        value="brewery"
+      />
+      <label
+        className="hidden"
+        for="brewery-button"
+      >
+        Brewery
+      </label>
+    </div>
+    <input
+      className="hidden"
+      name="logo"
+      onChange={[Function]}
+      placeholder="Upload logo"
+      type="file"
+    />
+    <button
+      className="hidden"
+      onClick={[Function]}
+    >
+      Upload!
+    </button>
+    <button
+      className="signin-button"
+      onClick={[Function]}
+    >
+      Sign In
+    </button>
+  </form>
+  <button
+    className="signup-button"
+    onClick={[Function]}
+  >
+    First Time Here? Sign Up!
+  </button>
+</main>
+`;

--- a/src/tests/__snapshots__/NavBar.test.js.snap
+++ b/src/tests/__snapshots__/NavBar.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`NAVBAR should match the snapshot 1`] = `
+<nav>
+  <ul
+    className="nav-controls"
+  >
+    <li
+      className="nav-control my-profile"
+    >
+      My Profile
+    </li>
+    <li
+      className="nav-control browse"
+    >
+      Browse
+    </li>
+    <li
+      className="nav-control breweries"
+    >
+      Breweries
+    </li>
+    <li
+      className="nav-control food-trucks"
+    >
+      Food Trucks
+    </li>
+    <li
+      className="nav-control cancellations"
+    >
+      Cancellations
+    </li>
+    <input
+      className="search-input"
+      placeholder="Search"
+    />
+  </ul>
+</nav>
+`;

--- a/src/tests/actions.test.js
+++ b/src/tests/actions.test.js
@@ -8,7 +8,7 @@ describe('actions', () => {
     const expectedAction = {
       type: 'LOAD_BREWERIES',
       breweries
-    };
+    };    
     const result = Actions.loadBreweries(mockBreweries);
     expect(result).toEqual(expectedAction);
   });


### PR DESCRIPTION
Add parens to make actions implicit returns, passing most actions tests. Removed load cancellations action. Removed Console logs. Change toggle sign in to use bang operator

## Description:

This PR addresses issue N/A

The changes made to the codebase in this PR:

Added Parens to make actions implicit returns, passing most actions tests

Removed load cancellations action

Removed Console logs

Changed Toggle sign in to use bang operator to be a toggle-action (removed in later PR)

## Testing 

These changes affect the following tests:

All tests in the actions file now passing!! 

```
All tests in the actions.test file have been changed to passing. The main problem was not in the test files but rather in the way the actions were written. Implicit returns on objects can be confusing since they need the parens! I often forget that as well.

```

## Requests for review

Areas of concern:

No real noteworthy areas of concern as the next PR has addressed some of these areas.